### PR TITLE
Unified the two `withdraw` functions

### DIFF
--- a/contracts/SafeTokenLock.sol
+++ b/contracts/SafeTokenLock.sol
@@ -66,7 +66,8 @@ contract SafeTokenLock is ISafeTokenLock, Ownable2Step {
         emit Unlocked(msg.sender, index, amount);
     }
 
-    function _withdraw(uint32 maxUnlocks) internal returns (uint96 amount) {
+    // @inheritdoc ISafeTokenLock
+    function withdraw(uint32 maxUnlocks) external returns (uint96 amount) {
         User memory _user = users[msg.sender];
         uint32 _index = _user.unlockStart;
         uint32 unlockEnd = _user.unlockEnd > _index + maxUnlocks && maxUnlocks != 0 ? _index + maxUnlocks : _user.unlockEnd;
@@ -84,17 +85,6 @@ contract SafeTokenLock is ISafeTokenLock, Ownable2Step {
             users[msg.sender] = User(_user.locked, _user.unlocked - amount, _index, _user.unlockEnd);
             SAFE_TOKEN.transfer(msg.sender, uint256(amount));
         }
-    }
-
-    // @inheritdoc ISafeTokenLock
-    function withdraw() external returns (uint96 amount) {
-        amount = _withdraw(0);
-    }
-
-    // @inheritdoc ISafeTokenLock
-    function withdraw(uint32 maxUnlocks) external returns (uint96 amount) {
-        if (maxUnlocks == 0) revert ZeroValue();
-        amount = _withdraw(maxUnlocks);
     }
 
     // @inheritdoc ISafeTokenLock

--- a/contracts/interfaces/ISafeTokenLock.sol
+++ b/contracts/interfaces/ISafeTokenLock.sol
@@ -30,20 +30,10 @@ interface ISafeTokenLock {
     function unlock(uint96 amount) external returns (uint32 index);
 
     /**
-     * @notice Withdraws the unlocked tokens of all unlock operations initiated by the caller.
-     * @return amount The amount of tokens withdrawn.
-     * @dev Calling this function without any unlock operation or maturing unlock operation will not revert.
-     * Gas Usage (major usage only): SLOAD users[caller] + n SLOAD unlocks[i][caller] + n Event Emits
-     * + n Zero assignment SSTORE unlocks[i][caller] + SSTORE users[caller] + SLOAD SAFE_TOKEN + Token Transfer
-     * where n can be as high as `unlockEnd - unlockStart`.
-     */
-    function withdraw() external returns (uint96 amount);
-
-    /**
      * @notice Withdraws the unlocked tokens of `maxUnlocks` oldest operations initiated by the caller.
      * @param maxUnlocks The number of unlock operations to be withdrawn.
      * @return amount The amount of tokens withdrawn.
-     * @dev Calling this function with zero `maxUnlocks` will revert. This is to encourage the caller to use `withdraw` function in those cases.
+     * @dev Calling this function with zero `maxUnlocks` will result in withdrawing all matured unlock operations.
      * Gas Usage (major usage only): SLOAD users[caller] + n SLOAD unlocks[i][caller] + n Event Emits
      * + n Zero assignment SSTORE unlocks[i][caller] + SSTORE users[caller] + SLOAD SAFE_TOKEN + Token Transfer
      * where n can be as high as max(`unlockEnd - unlockStart`, `maxUnlocks`).

--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -59,7 +59,8 @@ contract SafeTokenLock is ISafeTokenLock {
     */
   }
 
-  function _withdraw(uint32 maxUnlocks) external returns (uint96 amount) {
+  // @inheritdoc ISafeTokenLock
+  function withdraw(uint32 maxUnlocks) external returns (uint96 amount) {
     /**
         1. Read the `users[caller]` to `User memory user`.
         2. Based on the passed maxUnlocks, decide on the `unlockEnd`.
@@ -75,21 +76,6 @@ contract SafeTokenLock is ISafeTokenLock {
 
         Gas Usage (major usage only): SLOAD users[caller] + n SLOAD unlocks[i][caller] + n Event Emits + n Zero assignment SSTORE unlocks[i][caller] + SSTORE users[caller] + SLOAD SAFE_TOKEN + Token Transfer
         where n can be as high as `unlockEnd - unlockStart`.
-    */
-  }
-
-  // @inheritdoc ISafeTokenLock
-  function withdraw() external returns (uint96 amount) {
-    /**
-        1. Call `_withdraw(0)`.
-    */
-  }
-
-  // @inheritdoc ISafeTokenLock
-  function withdraw(uint32 maxUnlocks) external returns (uint96 amount) {
-    /**
-        1. Check if passed `maxUnlocks` is zero. If yes, revert. Else continue.
-        2. Call `_withdraw(maxUnlocks)`.
     */
   }
 


### PR DESCRIPTION
This PR unifies both `withdraw(...)` and `withdraw(uint32)` based on the discussion in this [thread](https://github.com/safe-global/safe-locking/pull/39#discussion_r1482672047).

The current implementation withdraws all matured unlock operations when zero is passed, and withdraws `m` matured unlock operations when `n` is passed, where `m` is the latest sequential matured unlock operations and `m <= n`.

This eliminates the need to have two `withdraw` functions and can be considered much simpler to use.