### PR TITLE
Adjust Contract NatSpec Documentation

### DIFF
--- a/contracts/SafeTokenLock.sol
+++ b/contracts/SafeTokenLock.sol
@@ -7,8 +7,9 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
- * @title SafeTokenLock - A Locking Contract for the Safe Tokens.
+ * @title SafeTokenLock - A Locking Contract for Safe Tokens.
  * @author @safe-global/safe-protocol
+ * @custom:security-contact bounty@safe.global
  */
 contract SafeTokenLock is ISafeTokenLock, Ownable2Step {
     struct User {
@@ -25,8 +26,8 @@ contract SafeTokenLock is ISafeTokenLock, Ownable2Step {
     /* solhint-disable var-name-mixedcase */
     IERC20 public immutable SAFE_TOKEN; // Safe Token Address.
     uint64 public immutable COOLDOWN_PERIOD; // Contains the cooldown period. Default will be 30 days.
-
     /* solhint-enable var-name-mixedcase */
+
     mapping(address => User) public users; // Contains the address => user info struct.
     mapping(uint32 => mapping(address => UnlockInfo)) public unlocks; // Contains the Unlock id => user => Unlock Info struct.
 

--- a/contracts/interfaces/ISafeTokenLock.sol
+++ b/contracts/interfaces/ISafeTokenLock.sol
@@ -2,9 +2,10 @@
 pragma solidity 0.8.23;
 
 /**
- * @title ISafeTokenLock - An interface of the SafeTokenLock Contract.
+ * @title ISafeTokenLock - The Interface for the Safe Token Locking Contract.
  * @author @safe-global/safe-protocol
- * @dev The contract describes the function signature and events used in the Safe Token Lock Contract.
+ * @dev The contract describes the function signature and events used in the Safe token locking contract.
+ * @custom:security-contact bounty@safe.global
  */
 interface ISafeTokenLock {
     event Locked(address indexed holder, uint96 amount);


### PR DESCRIPTION
This PR adjusts the NatSpec documentation for the the top level items (i.e. the Safe token locking contract and interface). In particular, it adds the `custom:security-contact` which was suggested by the OZ team during an unrelated audit, as well as some minor grammar/capitalization fixes. 