### PR TITLE
Fix Timestamp Comment

### DIFF
--- a/contracts/SafeTokenLock.sol
+++ b/contracts/SafeTokenLock.sol
@@ -20,7 +20,7 @@ contract SafeTokenLock is ISafeTokenLock, Ownable2Step {
     }
     struct UnlockInfo {
         uint96 amount; // For 1 Billion Safe Tokens, this is enough. 10 ** 27 < 2 ** 96
-        uint64 unlockedAt; // Valid until Year: 2554.
+        uint64 unlockedAt; // Valid for billions of years.
     }
 
     /* solhint-disable var-name-mixedcase */


### PR DESCRIPTION
`2**64` seconds is:

```
const seconds = 2 ** 64
const minutes = seconds / 60
const hours = minutes / 60
const days = hours / 24
const years = days / 365
```

And `Math.trunc(Math.log10(years)) == 11`, so the order of hundreds of billion of years.

This PR fixes the comment as it was inaccurate.