### PR TITLE
Rename `totalBalance` to `userTokenBalance`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Safe locking contract facilitates locking Safe tokens. Users can lock and unlock
   - **50 SAFE** locked for **500 blocks**
 
 - `withdraw(...)` is defined to withdraw all matured unlocks (unlocks whose unlock time is greater than `block.timestamp`). This is an `O(n)` operation (where `n` is the number of matured unlocks). In order to support more deterministic gas usage, a `withdraw(maxUnlocks)` function is also provided to withdraw up to `maxUnlocks` of the oldest matured unlocks. For example, `withdraw(1)` can be used to withdraw only the oldest unlock if it is already matured, which is an `O(1)` operation.
-- `totalBalance` returns the total `SAFE` token balance belonging to the `holder` within the locking contract, this includes locked tokens, unlocked tokens, and ready to withdraw tokens.
+- `userTokenBalance` returns the total `SAFE` token balance belonging to the `holder` within the locking contract, this includes locked tokens, unlocked tokens, and ready to withdraw tokens.
 - Full accounting of locked tokens per user can be computable based on emitted events.
-- The total `$SAFE` token balance in the locking contract belonging to any user can be readable on-chain or via a standard `eth_call` JSON RPC request. This MUST be made available by the `totalBalance(...)` contract method.
+- The total `$SAFE` token balance in the locking contract belonging to any user can be readable on-chain or via a standard `eth_call` JSON RPC request. This MUST be made available by the `userTokenBalance(...)` contract method.
 - The locking contract can allow simultaneous token unlock requests with separate cooldown ending timestamps based on an immutable cooldown period.
 - The contract cannot allow the total sum of unlock request amounts to exceed the token holder’s `SAFE` balance in the contract.
 - A withdrawal will withdraw the complete amount of its corresponding unlock request. That is, if a user calls `unlock(amount)`, then `withdraw()`, that unlock once matured, should transfer exactly `amount` `$SAFE` tokens to the holder (assuming no other unlocks were matured apart from that particular unlock operation).

--- a/certora/specs/SafeTokenLock.spec
+++ b/certora/specs/SafeTokenLock.spec
@@ -48,9 +48,9 @@ rule doesNotAffectOtherUserBalance(method f) {
     calldataarg args;
     require (e.msg.sender != otherUser);
 
-    uint96 otherUserBalanceBefore = totalBalance(e, otherUser);
+    uint96 otherUserBalanceBefore = userTokenBalance(e, otherUser);
     f(e,args);
-    assert totalBalance(e, otherUser) == otherUserBalanceBefore;
+    assert userTokenBalance(e, otherUser) == otherUserBalanceBefore;
 }
 
 rule cannotWithdrawMoreThanUnlocked() {

--- a/contracts/SafeTokenLock.sol
+++ b/contracts/SafeTokenLock.sol
@@ -107,7 +107,7 @@ contract SafeTokenLock is ISafeTokenLock, Ownable2Step {
     /**
      * @inheritdoc ISafeTokenLock
      */
-    function totalBalance(address holder) external view returns (uint96 amount) {
+    function userTokenBalance(address holder) external view returns (uint96 amount) {
         return _users[holder].locked + _users[holder].unlocked;
     }
 

--- a/contracts/interfaces/ISafeTokenLock.sol
+++ b/contracts/interfaces/ISafeTokenLock.sol
@@ -82,11 +82,11 @@ interface ISafeTokenLock {
     function withdraw(uint32 maxUnlocks) external returns (uint96 amount);
 
     /**
-     * @notice Returns the amount of tokens associated to the specified holder.
+     * @notice Returns the amount of Safe tokens associated to the specified holder.
      * @param holder The address of the holder.
-     * @return amount The amount of (locked + to be unlocked + withdrawable) tokens of the holder.
+     * @return amount The amount of (locked + to be unlocked + withdrawable) Safe tokens of the holder.
      */
-    function totalBalance(address holder) external returns (uint96 amount);
+    function userTokenBalance(address holder) external returns (uint96 amount);
 
     /**
      * @notice Returns user information for the specified address.

--- a/docs/Implementation.md
+++ b/docs/Implementation.md
@@ -80,7 +80,7 @@ contract SafeTokenLock is ISafeTokenLock {
   }
 
   // @inheritdoc ISafeTokenLock
-  function totalBalance(address holder) external returns (uint96 amount) {
+  function userTokenBalance(address holder) external returns (uint96 amount) {
     /**
         Return the amount from `users[caller].locked` + `users[caller].unlocked`.
 

--- a/test/SafeTokenLock.spec.ts
+++ b/test/SafeTokenLock.spec.ts
@@ -78,7 +78,7 @@ describe('SafeTokenLock', function () {
 
       // Checking Locked Token details
       expect((await safeTokenLock.getUser(alice)).locked).to.equal(tokenToLock)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock)
     })
 
     it('Should not lock zero tokens', async function () {
@@ -122,7 +122,7 @@ describe('SafeTokenLock', function () {
 
       // Checking Final Locked Token details
       expect((await safeTokenLock.getUser(alice)).locked).to.equal(totalTokensToLock)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(totalTokensToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(totalTokensToLock)
     })
 
     it('Should be possible to lock all tokens', async function () {
@@ -142,7 +142,7 @@ describe('SafeTokenLock', function () {
 
       // Checking Locked Token details
       expect((await safeTokenLock.getUser(alice)).locked).to.equal(tokenToLock)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock)
     })
 
     it('Should not lock tokens without transferring token', async function () {
@@ -198,7 +198,7 @@ describe('SafeTokenLock', function () {
       expect((await safeTokenLock.getUser(alice)).unlockEnd).to.equal(1)
       expect((await safeTokenLock.getUnlock(alice, 0)).amount).to.equal(tokenToUnlock)
       expect((await safeTokenLock.getUnlock(alice, 0)).unlockedAt).to.equal(expectedUnlockedAt)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock)
     })
 
     it('Should not unlock zero tokens', async function () {
@@ -267,7 +267,7 @@ describe('SafeTokenLock', function () {
       expect((await safeTokenLock.getUser(alice)).unlocked).to.equal(tokenToUnlock * BigInt(index))
       expect((await safeTokenLock.getUser(alice)).unlockStart).to.equal(0)
       expect((await safeTokenLock.getUser(alice)).unlockEnd).to.equal(index)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock)
     })
 
     it('Should be possible to unlock all tokens', async function () {
@@ -300,7 +300,7 @@ describe('SafeTokenLock', function () {
       expect((await safeTokenLock.getUser(alice)).unlockEnd).to.equal(1)
       expect((await safeTokenLock.getUnlock(alice, 0)).amount).to.equal(tokenToUnlock)
       expect((await safeTokenLock.getUnlock(alice, 0)).unlockedAt).to.equal(expectedUnlockedAt)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToUnlock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToUnlock)
     })
 
     it('Should not reduce the total token before & after unlock', async function () {
@@ -375,8 +375,8 @@ describe('SafeTokenLock', function () {
       expect((await safeTokenLock.getUnlock(alice, index)).unlockedAt).to.equal(expectedUnlockedAtAlice)
       expect((await safeTokenLock.getUnlock(bob, index)).amount).to.equal(tokenToUnlockBob)
       expect((await safeTokenLock.getUnlock(bob, index)).unlockedAt).to.equal(expectedUnlockedAtBob)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLockAlice)
-      expect(await safeTokenLock.totalBalance(bob)).to.equal(tokenToLockBob)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLockAlice)
+      expect(await safeTokenLock.userTokenBalance(bob)).to.equal(tokenToLockBob)
     })
   })
 
@@ -419,7 +419,7 @@ describe('SafeTokenLock', function () {
       expect(aliceUnlockEndAfter).to.equal(aliceUnlockEndBefore)
       expect((await safeTokenLock.getUnlock(alice, 0)).amount).to.equal(0)
       expect((await safeTokenLock.getUnlock(alice, 0)).unlockedAt).to.equal(0)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock - tokenToUnlock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock - tokenToUnlock)
     })
 
     it('Should allow withdraw call even if no tokens are unlocked', async function () {
@@ -475,7 +475,7 @@ describe('SafeTokenLock', function () {
         expect((await safeTokenLock.getUnlock(alice, index)).amount).to.equal(0)
         expect((await safeTokenLock.getUnlock(alice, index)).unlockedAt).to.equal(0)
       }
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock - tokenToUnlock * BigInt(index))
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock - tokenToUnlock * BigInt(index))
     })
 
     it('Should withdraw all matured unlocked tokens together by passing zero as maxUnlocks', async function () {
@@ -522,7 +522,7 @@ describe('SafeTokenLock', function () {
         expect((await safeTokenLock.getUnlock(alice, index)).amount).to.equal(0)
         expect((await safeTokenLock.getUnlock(alice, index)).unlockedAt).to.equal(0)
       }
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock - tokenToUnlock * BigInt(index))
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock - tokenToUnlock * BigInt(index))
     })
 
     it('Should withdraw multiple times correctly', async function () {
@@ -602,7 +602,7 @@ describe('SafeTokenLock', function () {
       for (; index < 10; index++) {
         expect((await safeTokenLock.getUnlock(alice, index)).amount).to.equal(tokenToUnlock)
       }
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock - tokenToUnlock * BigInt(6))
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock - tokenToUnlock * BigInt(6))
     })
 
     it('Should withdraw multiple times correctly with specified and zero maxUnlocks', async function () {
@@ -679,7 +679,7 @@ describe('SafeTokenLock', function () {
         expect((await safeTokenLock.getUnlock(alice, index)).amount).to.equal(0)
         expect((await safeTokenLock.getUnlock(alice, index)).unlockedAt).to.equal(0)
       }
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(0)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(0)
     })
 
     it('Should not revert if passed with maxUnlocks > unlock operations and withdraw based on unlock timestamp', async function () {
@@ -868,7 +868,7 @@ describe('SafeTokenLock', function () {
       expect(aliceUnlockEndAfter).to.equal(aliceUnlockEndBefore)
       expect((await safeTokenLock.getUnlock(alice, 0)).amount).to.equal(0)
       expect((await safeTokenLock.getUnlock(alice, 0)).unlockedAt).to.equal(0)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(0)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(0)
     })
 
     it('Should emit Withdrawn event when tokens are withdrawn correctly', async function () {
@@ -945,13 +945,13 @@ describe('SafeTokenLock', function () {
       await safeTokenLock.connect(alice).lock(tokenToLock)
 
       // Checking Total Balance of User after Lock (Locked: tokenToLock, Unlocked: 0)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock)
 
       // Unlocking tokens
       await safeTokenLock.connect(alice).unlock(tokenToUnlock)
 
       // Checking Total Balance of User after Unlock (Locked: tokenToLock - tokenToUnlock, Unlocked: tokenToUnlock)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock)
 
       // Getting unlocked at timestamp and increasing timestamp
       const unlockedAt = (await safeTokenLock.getUnlock(alice, 0)).unlockedAt
@@ -961,7 +961,7 @@ describe('SafeTokenLock', function () {
       await safeTokenLock.connect(alice).withdraw(0)
 
       // Checking Total Balance of User after Withdraw (Locked: tokenToLock - tokenToUnlock, Unlocked: 0)
-      expect(await safeTokenLock.totalBalance(alice)).to.equal(tokenToLock - tokenToUnlock)
+      expect(await safeTokenLock.userTokenBalance(alice)).to.equal(tokenToLock - tokenToUnlock)
     })
   })
 


### PR DESCRIPTION
Fixes #67 

This PR changes the name of `totalBalance` function to `userTokenBalance` to better reflect that it returns the user's Safe token balance that is held in the locking contract.