### PR TITLE
SafeToken related FVs in SafeTokenLock Contract

### DIFF
--- a/certora/specs/SafeTokenLock.spec
+++ b/certora/specs/SafeTokenLock.spec
@@ -54,6 +54,9 @@ invariant safeTokenSelfBalanceIsZero()
     safeTokenContract.balanceOf(safeTokenContract) == 0;
 
 // Verify that Safe Token Contract cannot lock tokens.
+// While this invariant is not important for the Safe locking contract per se,
+// having the Safe token contract lock or hold balance could cause strange behaviours
+// and cuase other rules and invariants to not hold.
 invariant safeTokenCannotLock()
     userTokenBalance(safeTokenContract) == 0
     {


### PR DESCRIPTION
This PR contains two invariants to be proven:

- [x] `safeTokenSelfBalanceIsZero` - The Safe Token Contract should not have a Safe Token Balance.
- [x] `safeTokenCannotLock` - The Safe Token should not be able to lock tokens in the Safe Token Lock.

These two invariants are proved through Certora and are required for other rules in case of arbitrary states.