### PR TITLE
Formally Verify `withdraw` Commutativity

### DIFF
--- a/certora/specs/SafeTokenLock.spec
+++ b/certora/specs/SafeTokenLock.spec
@@ -360,19 +360,12 @@ rule cannotUnlockPastMaxUint32(method f, address holder) filtered {
 }
 
 // Verify that withdrawing is commutative. That is, withdrawing with
-// `maxUnlocks` of `n` then `m`, is equivalent to `m` then `n`. An exception to
-// this rule is if the the user's `unlockEnd + maxUnlock` could overflow, but
-// reaching these high values of `unlockEnd` is not feasible.
-// this rule are noted below.
+// `maxUnlocks` of `n` then `m`, is equivalent to `m` then `n`.
 rule withdrawIsCommutative(uint32 maxUnlocks1, uint32 maxUnlocks2) {
     env e;
 
     requireInvariant unlockAmountsAreNonZero(e.msg.sender);
     requireInvariant contractCannotOperateOnItself();
-
-    // Exception: `unlockEnd + maxUnlocks` cannot overflow. Otherwise, there is
-    // an exception to commutativity with `maxUnlocks2 == 0`.
-    require getUser(e.msg.sender).unlockEnd + maxUnlocks1 <= MAX_UINT(32);
 
     storage init = lastStorage;
 

--- a/contracts/SafeTokenLock.sol
+++ b/contracts/SafeTokenLock.sol
@@ -102,9 +102,12 @@ contract SafeTokenLock is ISafeTokenLock, TokenRescuer {
     function withdraw(uint32 maxUnlocks) external returns (uint96 amount) {
         User memory user = _users[msg.sender];
         uint32 index = user.unlockStart;
-        uint32 unlockEnd = user.unlockEnd > index + maxUnlocks && maxUnlocks != 0 ? index + maxUnlocks : user.unlockEnd;
+        uint32 withdrawEnd = user.unlockEnd;
+        if (maxUnlocks != 0 && withdrawEnd > uint256(index) + uint256(maxUnlocks)) {
+            withdrawEnd = index + maxUnlocks;
+        }
 
-        for (; index < unlockEnd; index++) {
+        for (; index < withdrawEnd; index++) {
             UnlockInfo memory unlockInfo = _unlocks[index][msg.sender];
             if (unlockInfo.maturesAt > block.timestamp) break;
 


### PR DESCRIPTION
This PR adds a rule to verify withdrawal commutativity. This means that regardless of the order you withdraw, as long as you use the same `maxUnlocks` values you will end in the same result.

Note that there was previously an exception to commutativity when `maxUnlocks2 == 0`, as the second withdraw could overflow `user.unlockEnd + maxUnlocks1` and cause it to revert. I slightly reworked the `withdraw` function so this is no longer possible, and saved around 60 gas to boot :tada:. With this change, `withdraw` is fully commutative as well, with no exceptions.

I'm very happy overall, FV lead to code improvement :smile:.