### PR TITLE
Timestamp increase verification for Unlock operation

### DIFF
--- a/certora/specs/SafeTokenLock.spec
+++ b/certora/specs/SafeTokenLock.spec
@@ -472,6 +472,7 @@ rule getUnlockNeverReverts(address holder, uint32 index) {
     assert !lastReverted;
 }
 
+// Verify that the `SAFE_TOKEN` and `COOLDOWN_PERIOD` never changes.
 rule configurationNeverChanges(method f) filtered {
     f -> !f.isView
 } {


### PR DESCRIPTION
This PR contains the timestamp-based verification to see if the timestamp is increasing with each unlock operations. Also, checks if there are two or more unlock operations for a particular user, then the newer unlock operation maturity time is always higher than the older unlock operations.

Also added a rule which verifies that the `SAFE_TOKEN` and `COOLDOWN_PERIOD` is never changed.