### PR TITLE
Use Unchecked Math for Unlock Maturity Timestamp Computation

### DIFF
--- a/test/SafeTokenLock.spec.ts
+++ b/test/SafeTokenLock.spec.ts
@@ -392,9 +392,9 @@ describe('SafeTokenLock', function () {
       // Locking tokens of UnlockN contract
       await unlockN.lockAll()
 
-      // Multiple unlocks in a single transaction do not revert, up to a maximum of 1167 from the block gas limit.
-      await expect(unlockN.unlock(1167, { gasLimit: 30e6 })).to.not.be.rejected
-      await expect(unlockN.unlock(1168, { gasLimit: 30e6 })).to.be.rejected
+      // Multiple unlocks in a single transaction do not revert, up to a maximum restricted by the block gas limit.
+      await expect(unlockN.unlock(1169, { gasLimit: 30e6 })).to.not.be.rejected
+      await expect(unlockN.unlock(1170, { gasLimit: 30e6 })).to.be.rejected
     })
   })
 


### PR DESCRIPTION
This PR changes the computation of the `maturesAt` timestamp to be unchecked. The exact reason is documented in the contract, but it boils down to:
- We will not reach this condition in our lifetime
- Has the nice property that, if someone has tokens in the Safe token lock contract hundreds of billions of years after the Sun went supernova, they will be able to withdraw them immediately. I mean, they earned it locking Safe for so long!