### PR TITLE
Unlock Index related FV

### DIFF
--- a/certora/specs/SafeTokenLock.spec
+++ b/certora/specs/SafeTokenLock.spec
@@ -584,8 +584,6 @@ rule unlockIndexShouldReturnLastEndIndex() {
     env e;
 
     require e.msg.value == 0;
-    require ghostUserLocked[e.msg.sender] > 0;
-
     requireInvariant unlockStartBeforeEnd(e.msg.sender);
 
     uint32 end = getUser(e.msg.sender).unlockEnd;


### PR DESCRIPTION
This PR contains one rule `unlockIndexShouldReturnLastEndIndex` which verifies that the `index` returned after calling `unlock(...)` will return the last `unlockEnd`.