### PR TITLE
Explicitely Revert On Invalid Total Supply

### DIFF
--- a/contracts/test/TestERC20.sol
+++ b/contracts/test/TestERC20.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.0 <0.9.0;
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract TestERC20 is ERC20 {
-    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+    constructor() ERC20("Test ERC20", "TEST") {}
 
     function mint(address account, uint256 value) external {
         _mint(account, value);


### PR DESCRIPTION
This PR slightly changes the constructor logic to require that the token that is passed in has a total supply that fits in a `uint96`. This change was done since:
1. The contract assumes this to be true for it to function correctly. I thought it would be good to document it explicitly as a condition that is verified on-chain
2. The gas cost overhead of the check is only payed once on deployment
3. We still revert when constructing the a locking contract instance with `address(0)`.

Added a new unit test to verify new logic.