### PR TITLE
Disabling `renounceOwnership(...)`

### DIFF
--- a/certora/specs/SafeTokenLock.spec
+++ b/certora/specs/SafeTokenLock.spec
@@ -409,9 +409,6 @@ rule onlyOwnerOrPendingOwnerCanChangeOwner(method f) filtered {
 
     f@withrevert(e, args);
 
-    assert lastReverted
-        => (e.msg.sender == ownerBefore
-            && f.selector == sig:renounceOwnership().selector);
     assert owner() != ownerBefore
         => (e.msg.sender == pendingOwnerBefore
             && f.selector == sig:acceptOwnership().selector);

--- a/contracts/SafeTokenLock.sol
+++ b/contracts/SafeTokenLock.sol
@@ -201,8 +201,9 @@ contract SafeTokenLock is ISafeTokenLock, TokenRescuer {
     /**
      * @notice Disables renouncing ownership.
      * @dev Allowing renouncing ownership would make the Token Rescue mechanism unusable.
+     *      `onlyOwner` modifier is removed as the function reverts on all cases.
      */
-    function renounceOwnership() public view override onlyOwner {
+    function renounceOwnership() public pure override {
         revert RenounceOwnershipDisabled();
     }
 }

--- a/test/SafeTokenLock.spec.ts
+++ b/test/SafeTokenLock.spec.ts
@@ -1159,7 +1159,7 @@ describe('SafeTokenLock', function () {
   })
 
   describe('Ownership', function () {
-    it('Should not allow renouncing ownership', async function () {
+    it('Should not allow renouncing ownership by owner', async function () {
       const { safeTokenLock, owner } = await setupTests()
 
       expect(safeTokenLock.connect(owner).renounceOwnership()).to.be.revertedWithCustomError(safeTokenLock, 'RenounceOwnershipDisabled')
@@ -1171,9 +1171,7 @@ describe('SafeTokenLock', function () {
     it('Should not allow renouncing ownership by non-owner', async function () {
       const { safeTokenLock, alice } = await setupTests()
 
-      expect(safeTokenLock.connect(alice).renounceOwnership())
-        .to.be.revertedWithCustomError(safeTokenLock, 'OwnableUnauthorizedAccount')
-        .withArgs(alice)
+      expect(safeTokenLock.connect(alice).renounceOwnership()).to.be.revertedWithCustomError(safeTokenLock, 'RenounceOwnershipDisabled')
     })
   })
 })


### PR DESCRIPTION
This PR disables the `renounceOwnership(...)` and adds some FVs and tests to ensure that an `owner` can never renounce his ownership.

Linked to #88