### PR TITLE
Bumped to `v1` and added Locking Contract Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ Same as before.
    Type: `uint32`
    Value: `86400`
 
-Deployment Parameters can also be found in [deployments.ts](./src/utils/deployment.ts)
-
 ## Changes
 
 ### General

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,28 @@ Safe Locking Contract Address: [0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2](http
 
 Same as before.
 
+## Constructor Argument
+
+1. Name: `initialOwner`
+   Type: `address`
+   Value: `0x8CF60B289f8d31F737049B590b5E4285Ff0Bd1D1`
+
+2. Name: `safeToken`
+   Type: `address`
+   Value: `0x5aFE3855358E112B5647B952709E6165e1c1eEEe`
+
+3. Name: `cooldownPeriod`
+   Type: `uint32`
+   Value: `86400`
+
+Deployment Parameters can also be found in [deployments.ts](./src/utils/deployment.ts)
+
 ## Changes
 
 ### General
 
-Added `SafeTokenLock` address in README.
+- Release of the Safe token locking contracts.
+- Added `SafeTokenLock` address in README.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+# Version 1.0.0
+
+## Address
+
+Safe Locking Contract Address: [0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2](https://etherscan.io/address/0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2)
+
+## Compiler settings
+
+Same as before.
+
+## Changes
+
+### General
+
+Added `SafeTokenLock` address in README.
+
+### Fixes
+
+None
+
 # Version 0.1.0
 
 ## Compiler settings

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Safe locking contract facilitates locking Safe tokens. Users can lock and unlock
 
 ## Mainnet Deployment
 
-Safe Locking Contract Address: [0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2](https://etherscan.io/address/0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2)
+The Safe locking contract was deployed to Ethereum mainnet at address [`0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2`](https://etherscan.io/address/0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2). The deployment transaction was [`0xd90bbe97f71ca9cff6e7ee545a773d25fa34260624df681bf04592f5e7301b2e`](https://etherscan.io/tx/0xd90bbe97f71ca9cff6e7ee545a773d25fa34260624df681bf04592f5e7301b2e)
 
 ## Contract
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Safe locking contract facilitates locking Safe tokens. Users can lock and unlock
 
 ## Mainnet Deployment
 
-The Safe locking contract was deployed to Ethereum mainnet at address [`0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2`](https://etherscan.io/address/0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2). The deployment transaction was [`0xd90bbe97f71ca9cff6e7ee545a773d25fa34260624df681bf04592f5e7301b2e`](https://etherscan.io/tx/0xd90bbe97f71ca9cff6e7ee545a773d25fa34260624df681bf04592f5e7301b2e)
+The Safe locking contract was deployed to Ethereum mainnet at address [`0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2`](https://etherscan.io/address/0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2). The deployment transaction was [`0xd90bbe97f71ca9cff6e7ee545a773d25fa34260624df681bf04592f5e7301b2e`](https://etherscan.io/tx/0xd90bbe97f71ca9cff6e7ee545a773d25fa34260624df681bf04592f5e7301b2e).
 
 ## Contract
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Safe locking contract facilitates locking Safe tokens. Users can lock and unlock tokens anytime and also withdraw after the `COOLDOWN_PERIOD` is over. The contract also provides feature controlled by the admin address to recover ERC20 tokens other than Safe tokens.
 
+## Mainnet Deployment
+
+Safe Locking Contract Address: [0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2](https://etherscan.io/address/0x0a7CB434f96f65972D46A5c1A64a9654dC9959b2)
+
 ## Contract
 
 ### Contract behaviour

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@safe-global/safe-locking",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@safe-global/safe-locking",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "@nomicfoundation/hardhat-network-helpers": "^1.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-locking",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Safe Token Locking Contract",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The PR adds `SafeTokenLock` address to documentations (CHANGELOG and README), and bumps the NPM version to `v1`.